### PR TITLE
Story voting

### DIFF
--- a/app/(stories)/actions.ts
+++ b/app/(stories)/actions.ts
@@ -1,7 +1,305 @@
 "use server";
+
 import { signOut } from "@/app/auth";
+import z from "zod";
+import { db, usersTable, storiesTable, votesTable, genVoteId } from "@/app/db";
+import { auth } from "@/app/auth";
+import { sql } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { unvoteRateLimit, voteRateLimit } from "@/lib/rate-limit";
+import { redirect } from "next/navigation";
 
 export async function signOutAction() {
   await signOut();
   return {};
+}
+
+const VoteActionSchema = z.object({
+  storyId: z.string(),
+});
+
+export type VoteActionData = {
+  error?:
+    | {
+        code: "INTERNAL_ERROR";
+        message: string;
+      }
+    | {
+        code: "VALIDATION_ERROR";
+        fieldErrors: {
+          [field: string]: string[];
+        };
+      }
+    | {
+        code: "RATE_LIMIT_ERROR";
+        message: string;
+      }
+    | {
+        code: "ALREADY_VOTED_ERROR";
+        message: string;
+      };
+};
+
+export async function voteAction(
+  formData: FormData
+): Promise<VoteActionData | void> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const data = VoteActionSchema.safeParse({
+    storyId: formData.get("storyId"),
+  });
+
+  if (!data.success) {
+    return {
+      error: {
+        code: "VALIDATION_ERROR",
+        fieldErrors: data.error.flatten().fieldErrors,
+      },
+    };
+  }
+
+  const user = (
+    await db
+      .select()
+      .from(usersTable)
+      .where(sql`${usersTable.id} = ${session.user.id}`)
+      .limit(1)
+  )[0];
+
+  if (!user) {
+    return {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "User not found",
+      },
+    };
+  }
+
+  const rl = await voteRateLimit.limit(user.id);
+
+  if (!rl.success) {
+    return {
+      error: {
+        code: "RATE_LIMIT_ERROR",
+        message: "Too many votes. Try again later",
+      },
+    };
+  }
+
+  // TODO: transaction
+  // await db.transaction(async (tx) => {
+  const tx = db;
+  try {
+    const story = (
+      await tx
+        .select({
+          id: storiesTable.id,
+          username: storiesTable.username,
+          submitted_by: storiesTable.submitted_by,
+          vote_id: votesTable.id,
+        })
+        .from(storiesTable)
+        .where(sql`${storiesTable.id} = ${data.data.storyId}`)
+        .leftJoin(
+          votesTable,
+          sql`${storiesTable.id} = ${votesTable.story_id} AND ${votesTable.user_id} = ${user.id}`
+        )
+        .limit(1)
+    )[0];
+
+    if (!story) {
+      throw new Error("Story not found");
+    }
+
+    if (story.vote_id) {
+      return {
+        error: {
+          code: "ALREADY_VOTED_ERROR",
+          message: "You already voted for this story",
+        },
+      };
+    }
+
+    await Promise.all([
+      tx.insert(votesTable).values({
+        id: genVoteId(),
+        user_id: user.id,
+        story_id: story.id,
+      }),
+      tx
+        .update(storiesTable)
+        .set({
+          points: sql`${storiesTable.points} + 1`,
+        })
+        .where(sql`${storiesTable.id} = ${story.id}`),
+      story.submitted_by
+        ? tx
+            .update(usersTable)
+            .set({
+              karma: sql`${usersTable.karma} + 1`,
+            })
+            .where(sql`${usersTable.id} = ${story.submitted_by}`)
+        : Promise.resolve(),
+    ]);
+
+    // revalidate all data, including points for all stories
+    revalidatePath("/", "layout");
+
+    return {};
+  } catch (err) {
+    console.error(err);
+    return {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Something went wrong",
+      },
+    };
+  }
+}
+
+const UnvoteActionSchema = z.object({
+  storyId: z.string(),
+});
+
+export type UnvoteActionData = {
+  error?:
+    | {
+        code: "INTERNAL_ERROR";
+        message: string;
+      }
+    | {
+        code: "VALIDATION_ERROR";
+        fieldErrors: {
+          [field: string]: string[];
+        };
+      }
+    | {
+        code: "RATE_LIMIT_ERROR";
+        message: string;
+      }
+    | {
+        code: "SELF_UNVOTE_ERROR";
+        message: string;
+      };
+};
+
+export async function unvoteAction(
+  formData: FormData
+): Promise<UnvoteActionData | void> {
+  const session = await auth();
+
+  if (!session?.user?.id) {
+    redirect("/login");
+  }
+
+  const data = UnvoteActionSchema.safeParse({
+    storyId: formData.get("storyId"),
+  });
+
+  if (!data.success) {
+    return {
+      error: {
+        code: "VALIDATION_ERROR",
+        fieldErrors: data.error.flatten().fieldErrors,
+      },
+    };
+  }
+
+  const user = (
+    await db
+      .select()
+      .from(usersTable)
+      .where(sql`${usersTable.id} = ${session.user.id}`)
+      .limit(1)
+  )[0];
+
+  if (!user) {
+    return {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "User not found",
+      },
+    };
+  }
+
+  const rl = await unvoteRateLimit.limit(user.id);
+
+  if (!rl.success) {
+    return {
+      error: {
+        code: "RATE_LIMIT_ERROR",
+        message: "Too many unvotes. Try again later",
+      },
+    };
+  }
+
+  // TODO: transaction
+  // await db.transaction(async (tx) => {
+  const tx = db;
+  try {
+    const story = (
+      await tx
+        .select({
+          id: storiesTable.id,
+          username: storiesTable.username,
+          submitted_by: storiesTable.submitted_by,
+          vote_id: votesTable.id,
+        })
+        .from(storiesTable)
+        .where(sql`${storiesTable.id} = ${data.data.storyId}`)
+        .leftJoin(
+          votesTable,
+          sql`${storiesTable.id} = ${votesTable.story_id} AND ${votesTable.user_id} = ${user.id}`
+        )
+        .limit(1)
+    )[0];
+
+    if (!story) {
+      throw new Error("Story not found");
+    }
+
+    if (story.submitted_by === user.id) {
+      return {
+        error: {
+          code: "SELF_UNVOTE_ERROR",
+          message: "You can't unvote your own story",
+        },
+      };
+    }
+
+    await Promise.all([
+      tx.delete(votesTable).where(sql`${votesTable.id} = ${story.vote_id}`),
+      tx
+        .update(storiesTable)
+        .set({
+          points: sql`${storiesTable.points} - 1`,
+        })
+        .where(sql`${storiesTable.id} = ${story.id}`),
+      story.submitted_by
+        ? tx
+            .update(usersTable)
+            .set({
+              karma: sql`${usersTable.karma} - 1`,
+            })
+            .where(sql`${usersTable.id} = ${story.submitted_by}`)
+        : Promise.resolve(),
+    ]);
+
+    // revalidate all data, including points for all stories
+    revalidatePath("/", "layout");
+
+    return {};
+  } catch (err) {
+    console.error(err);
+    return {
+      error: {
+        code: "INTERNAL_ERROR",
+        message: "Something went wrong",
+      },
+    };
+  }
 }

--- a/app/(stories)/opengraph-image.tsx
+++ b/app/(stories)/opengraph-image.tsx
@@ -2,9 +2,9 @@ export const runtime = "edge";
 export const revalidate = 60;
 
 import { ImageResponse } from "next/og";
-import { getStories, getStoriesCount } from "@/components/stories";
 import JSTimeAgo from "javascript-time-ago";
 import en from "javascript-time-ago/locale/en";
+import { getStories, getStoriesCount } from "@/components/stories";
 
 let timeAgo: JSTimeAgo | null = null;
 const numberFormatter = new Intl.NumberFormat("en-US");

--- a/app/db.ts
+++ b/app/db.ts
@@ -8,6 +8,7 @@ import {
   varchar,
   timestamp,
   AnyPgColumn,
+  uniqueIndex,
 } from "drizzle-orm/pg-core";
 import { customAlphabet } from "nanoid";
 import { nolookalikes } from "nanoid-dictionary";
@@ -79,8 +80,37 @@ export const storiesTable = pgTable(
   })
 );
 
+export const composeStoryId = (id: string) => {
+  return `story_${id}`;
+};
+
 export const genStoryId = () => {
-  return `story_${nanoid(12)}`;
+  return composeStoryId(nanoid(12));
+};
+
+export const votesTable = pgTable(
+  "votes",
+  {
+    id: varchar("id", { length: 256 }).primaryKey().notNull(),
+    user_id: varchar("user_id", { length: 256 })
+      .notNull()
+      .references(() => usersTable.id, { onDelete: "cascade" }),
+    story_id: varchar("story_id", { length: 256 })
+      .notNull()
+      .references(() => storiesTable.id, { onDelete: "cascade" }),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    story_id_user_id_idx: uniqueIndex("v_story_id_user_id_idx").on(
+      t.story_id,
+      t.user_id
+    ),
+  })
+);
+
+export const genVoteId = () => {
+  return `vote_${nanoid(12)}`;
 };
 
 export const commentsTable = pgTable(

--- a/components/comments.tsx
+++ b/components/comments.tsx
@@ -4,6 +4,7 @@ import { headers } from "next/headers";
 import { auth } from "@/app/auth";
 import { nanoid } from "nanoid";
 import { TimeAgo } from "@/components/time-ago";
+import { VoteIcon } from "@/components/icons/vote-icon";
 
 async function getComments({
   storyId,
@@ -146,23 +147,8 @@ function CommentItem({
             <span className="text-2xl text-[#FF9966] cursor-pointer">*</span>
           ) : (
             <>
-              <svg
-                height="12"
-                viewBox="0 0 32 16"
-                width="12"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="m2 27 14-29 14 29z" fill="#999" />
-              </svg>
-              <svg
-                className="transform rotate-180"
-                height="12"
-                viewBox="0 0 32 16"
-                width="12"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path d="m2 27 14-29 14 29z" fill="#999" />
-              </svg>
+              <VoteIcon />
+              <VoteIcon className="transform rotate-180" />
             </>
           )}
         </div>

--- a/components/icons/vote-icon.tsx
+++ b/components/icons/vote-icon.tsx
@@ -1,0 +1,13 @@
+export function VoteIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      height="14"
+      viewBox="0 0 32 16"
+      width="14"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="m2 27 14-29 14 29z" fill="#999" />
+    </svg>
+  );
+}

--- a/components/voting.tsx
+++ b/components/voting.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { unvoteAction, voteAction } from "@/app/(stories)/actions";
+import { VoteIcon } from "@/components/icons/vote-icon";
+import { useFormStatus } from "react-dom";
+
+export function VoteForm({
+  storyId,
+  votedByMe,
+}: {
+  storyId: string;
+  votedByMe: boolean;
+}) {
+  return (
+    <form action={voteAction} className="w-3.5">
+      <VoteFormFields storyId={storyId} votedByMe={votedByMe} />
+    </form>
+  );
+}
+
+function VoteFormFields({
+  storyId,
+  votedByMe,
+}: {
+  storyId: string;
+  votedByMe: boolean;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <>
+      <input type="hidden" name="storyId" value={storyId} />
+      {!votedByMe && !pending && (
+        <button>
+          <VoteIcon />
+        </button>
+      )}
+    </>
+  );
+}
+
+export function UnvoteForm({ storyId }: { storyId: string }) {
+  return (
+    <form action={unvoteAction} className="inline">
+      <UnvoteFormFields storyId={storyId} />
+    </form>
+  );
+}
+
+function UnvoteFormFields({ storyId }: { storyId: string }) {
+  const { pending } = useFormStatus();
+
+  return (
+    <>
+      <input type="hidden" name="storyId" value={storyId} />
+      {!pending && (
+        <>
+          <span aria-hidden="true"> | </span>
+          <button>unvote</button>
+        </>
+      )}
+    </>
+  );
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -39,3 +39,17 @@ export const newCommentRateLimit = new Ratelimit({
   analytics: true,
   prefix: "ratelimit:newcomment",
 });
+
+export const voteRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(25, "15 m"),
+  analytics: true,
+  prefix: "ratelimit:vote",
+});
+
+export const unvoteRateLimit = new Ratelimit({
+  redis,
+  limiter: Ratelimit.slidingWindow(25, "15 m"),
+  analytics: true,
+  prefix: "ratelimit:unvote",
+});

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react-highlight-words": "^0.16.7",
     "autoprefixer": "^10.0.1",
     "dotenv": "^16.3.1",
-    "drizzle-kit": "^0.20.9",
+    "drizzle-kit": "^0.20.13",
     "eslint": "^8",
     "eslint-config-next": "14.0.2",
     "next": "14.0.5-canary.41",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ devDependencies:
     specifier: ^16.3.1
     version: 16.3.1
   drizzle-kit:
-    specifier: ^0.20.9
-    version: 0.20.9
+    specifier: ^0.20.13
+    version: 0.20.13
   eslint:
     specifier: ^8
     version: 8.53.0
@@ -193,8 +193,8 @@ packages:
     dependencies:
       regenerator-runtime: 0.14.0
 
-  /@drizzle-team/studio@0.0.37:
-    resolution: {integrity: sha512-LZyAPGJBX43jsrVZh7+w1Jig/BC6PJx63ReHUYK+GRQYNY9UJNlPXmn1uC/LMRX+A7JwYM4Sr4Fg/hnJSqlfgA==}
+  /@drizzle-team/studio@0.0.39:
+    resolution: {integrity: sha512-c5Hkm7MmQC2n5qAsKShjQrHoqlfGslB8+qWzsGGZ+2dHMRTNG60UuzalF0h0rvBax5uzPXuGkYLGaQ+TUX3yMw==}
     dependencies:
       superjson: 2.2.1
     dev: true
@@ -1620,11 +1620,11 @@ packages:
       wordwrap: 1.0.0
     dev: true
 
-  /drizzle-kit@0.20.9:
-    resolution: {integrity: sha512-5oIbPFdfEEfzVSOB3MWGt70VSHv6W7qMAWCJ5xc6W1BxgGASipxuAuyXD59fx9S6QYTNNnuSuQFoIdnNTRWY2A==}
+  /drizzle-kit@0.20.13:
+    resolution: {integrity: sha512-j9oZSQXNWG+KBJm0Sg3S/zJpncHGKnpqNfFuM4NUxUMGTcihDHhP9SW6Jncqwb5vsP1Xm0a8JLm3PZUIspC/oA==}
     hasBin: true
     dependencies:
-      '@drizzle-team/studio': 0.0.37
+      '@drizzle-team/studio': 0.0.39
       '@esbuild-kit/esm-loader': 2.6.5
       camelcase: 7.0.1
       chalk: 5.3.0


### PR DESCRIPTION
- Votes table to track who voted for what and to prevent double-votes
- Authentication required to vote
- Cannot downvote own story
- Karma incremented/decremented on vote creation/deletion

Decisions:
- Story points could be inferred/generated from votes, but leaving the points column in place for now since stories begin with one point and ai-generated stories do not have a user. An alternative is to remove the points column, create a view on stories and votes to keep a votes tally, start every story at 0, and add 1 to the value in application code on retrieval to account for the implicit self-upvote on each story. But for now, this seems overly-complex compared to just maintaining the points separately. And transactions will help once supported.
- We could do something similar with user karma, but again, it's overly complex and doesn't leave much room for [abuse adjustments](https://news.ycombinator.com/newsfaq.html).
- A vote is created on story creation to leave room for the above ideas in the future, and to allow a single check to prevent both upvoting your own story and upvoting a story twice.
- Balanced immediate click feedback with avoiding larger client component scope by removing the vote/downvote buttons on click, but allowing revalidatePath to update the rest of the story entry:

https://github.com/rauchg/next-ai-news/assets/29106809/e99ecc4a-6323-47b8-9583-c6f49823071e